### PR TITLE
make options into normal keyword arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,10 @@ signal = Hist1D((randn(1000).+10)./3,-5:0.5:5)
 plot_stack(
            backgrounds=[h1, h2, h3, h4, h5, h6],
            data=[data],
-           signals=[signal], # TODO Not supported yet
-           options=Dict(
-            :xaxistitle => "Δϕ<sub>jj</sub> [GeV]",
-            :outputname => "plot.pdf",
-            :backgroundlabels => ["tt̄", "Higgs", "Drell-Yan", "tt̄Z", "ZZ", "VBS WW"],
-            :signallabels => ["VVH"],
-           )
+           signals=[signal],
+           xaxistitle = "Δϕ<sub>jj</sub> [GeV]",
+           outputname = "plot.pdf",
+           backgroundlabels = ["tt̄", "Higgs", "Drell-Yan", "tt̄Z", "ZZ", "VBS WW"],
+           signallabels = ["VVH"],
           )
 ```     

--- a/examples/example1/example1.jl
+++ b/examples/example1/example1.jl
@@ -1,5 +1,7 @@
 using PlotlyJSWrapper
 using FHist
+using Random
+Random.seed!(42)
 
 # Creating example histograms
 h1 = Hist1D(randn(3000),-5:0.5:5) * 0.1
@@ -19,13 +21,11 @@ plot_stack(
            backgrounds=[h1, h2, h3, h4, h5, h6],
            data=[data],
            signals=[signal, signal2, signal3, signal4],
-           options=Dict{Symbol, Any}(
-            :xaxistitle => "Δϕ<sub>jj</sub> [GeV]",
-            :outputname => "plot.pdf",
-            :backgroundlabels => ["tt̄", "Higgs", "Drell-Yan", "tt̄Z", "ZZ", "VBS WW"],
-            :signallabels => ["VVV", "VVH", "VHH", "HHH"],
-            :stacksignals => true,
-            :hideratio => false,
-            :showsignalsinratio => true,
-           )
+           xaxistitle = "Δϕ<sub>jj</sub> [GeV]",
+           outputname = "plot.pdf",
+           backgroundlabels = ["tt̄", "Higgs", "Drell-Yan", "tt̄Z", "ZZ", "VBS WW"],
+           signallabels = ["VVV", "VVH", "VHH", "HHH"],
+           stacksignals = true,
+           hideratio = false,
+           showsignalsinratio = true,
           )

--- a/examples/example2/example2.jl
+++ b/examples/example2/example2.jl
@@ -1,5 +1,7 @@
 using PlotlyJSWrapper
 using FHist
+using Random
+Random.seed!(42)
 
 # Creating example histograms
 h1 = Hist1D(randn(3000),-5:0.5:5) * 0.1
@@ -16,13 +18,11 @@ signal = Hist1D((randn(1000).+10)./3,-5:0.5:5) * 0.1
 plot_stack(
            backgrounds=[h1, h2, h3, h4, h5, h6],
            data=[data, data2],
-           signals=[signal], # TODO Not supported yet
-           options=Dict{Symbol, Any}(
-            :xaxistitle => "Δϕ<sub>jj</sub> [GeV]",
-            :outputname => "plot.pdf",
-            :backgroundlabels => ["tt̄", "Higgs", "Drell-Yan", "tt̄Z", "ZZ", "VBS WW"],
-            :datalabels => ["Data", "Different Data"],
-            :signallabels => ["VVH"],
-            :ratiorange => [0.0, 2.5],
-           )
+           signals=[signal],
+           xaxistitle = "Δϕ<sub>jj</sub> [GeV]",
+           outputname = "plot.pdf",
+           backgroundlabels = ["tt̄", "Higgs", "Drell-Yan", "tt̄Z", "ZZ", "VBS WW"],
+           datalabels = ["Data", "Different Data"],
+           signallabels = ["VVH"],
+           ratiorange = [0.0, 2.5],
           )

--- a/src/plot_stack.jl
+++ b/src/plot_stack.jl
@@ -1,5 +1,5 @@
 """
-    plot_stack(; backgrounds, signals=[], data=[], options::Dict{Symbol, Any}=default_options)
+    plot_stack(; backgrounds, signals=[], data=[], options...)
 
 Create HEP-style stacked plot with Data/MC ratio in the bottom panel.  
 
@@ -14,17 +14,15 @@ plot_stack(
            backgrounds=[h1, h2, h3, h4, h5, h6],
            data=[data],
            signals=[signal], # TODO Not supported yet
-           options=Dict(
-            :xaxistitle => "Δϕ<sub>jj</sub> [GeV]",
-            :outputname => "plot.pdf",
-            :backgroundlabels => ["tt̄", "Higgs", "Drell-Yan", "tt̄Z", "ZZ", "VBS WW"],
-            :signallabels => ["VVH"],
-           )
+           xaxistitle = "Δϕ<sub>jj</sub> [GeV]",
+           outputname = "plot.pdf",
+           backgroundlabels = ["tt̄", "Higgs", "Drell-Yan", "tt̄Z", "ZZ", "VBS WW"],
+           signallabels = ["VVH"],
           )
 ```
 
 """
-function plot_stack(; backgrounds, signals=Hist1D[], data=Hist1D[], options::Dict=default_options)
+function plot_stack(; backgrounds, signals=Hist1D[], data=Hist1D[], options...)
 
     #__________________________________________________________________________________
     #


### PR DESCRIPTION
up to you. I think this cleans up the "dict layer" and if people still want to feed a dict of options in, they can splat it with `plot_stack(backgrounds=[h], myoptions...)`