### PR TITLE
make output more flexible

### DIFF
--- a/src/options.jl
+++ b/src/options.jl
@@ -5,7 +5,7 @@ Default options of all the togglable options are documented here.
 
 # Output file name
 
-    :outputname => "plot.pdf", # TODO create output dir if not exist
+    :outputname => "plot.pdf", # or "plot.{pdf,png}" or "". TODO create output dir if not exist
 
 # Axes and labeling
 

--- a/src/plot_stack.jl
+++ b/src/plot_stack.jl
@@ -344,7 +344,7 @@ function plot_stack(; backgrounds, signals=Hist1D[], data=Hist1D[], options::Dic
     if !isempty(outputname)
         outputnamenoext = first(rsplit(outputname, "."; limit=2))
         # all possible output formats
-        outputs = ["$outputnamenoext.$ext" for ext in ["html", "pdf", "png"]]
+        outputs = ["$outputnamenoext.$ext" for ext in ["html", "pdf", "png", "svg"]]
         # those matching the specified filename (or pattern)
         for output in outputs[occursin.(Regex(outputname), outputs)]
             savefig(p, output, width=width, height=height);

--- a/src/plot_stack.jl
+++ b/src/plot_stack.jl
@@ -338,12 +338,17 @@ function plot_stack(; backgrounds, signals=Hist1D[], data=Hist1D[], options::Dic
     # Save!
     #
     #
-    # Get output name
-    outputnamewithoutextension = useroptions[:outputname][1:findlast(isequal('.'),useroptions[:outputname])-1]
-
-    # Save HTML
-    savefig(p, "$outputnamewithoutextension.html");
-    savefig(p, "$outputnamewithoutextension.pdf", width=width, height=height);
-    savefig(p, "$outputnamewithoutextension.png", width=width, height=height);
-
+    outputname = useroptions[:outputname]
+    # glob to regex
+    outputname = replace(outputname, r"\{|\,|\}" => s->Dict("{"=>"(","}"=>")",","=>"|")[s])
+    if !isempty(outputname)
+        outputnamenoext = first(rsplit(outputname, "."; limit=2))
+        # all possible output formats
+        outputs = ["$outputnamenoext.$ext" for ext in ["html", "pdf", "png"]]
+        # those matching the specified filename (or pattern)
+        for output in outputs[occursin.(Regex(outputname), outputs)]
+            savefig(p, output, width=width, height=height);
+        end
+    end
+    return p
 end


### PR DESCRIPTION
Based on discussion in https://github.com/sgnoohc/PlotlyJSWrapper.jl/issues/6

This PR returns the plotly plot object by default, so that it can be viewed in a notebook/manipulated/saved by the user. The PR also makes output naming more flexible:
- `outputname=""` saves nothing (so only the `p` will be returned)
- `outputname="plot.png"` saves just `plot.png`
- `outputname="plot.{pdf,png}"` saves `plot.pdf` and `plot.png` similar to what you'd expect in Bash

```julia
julia> @time plot_stack(backgrounds=[h], options=Dict(:outputname=>""));
  0.001717 seconds (4.62 k allocations: 502.602 KiB)

julia> @time plot_stack(backgrounds=[h], options=Dict(:outputname=>"plot.html"));
output = "plot.html"
  0.002857 seconds (5.78 k allocations: 667.195 KiB)

julia> @time plot_stack(backgrounds=[h], options=Dict(:outputname=>"plot.{png,pdf}"));
output = "plot.pdf"
output = "plot.png"
  0.127593 seconds (9.36 k allocations: 1.493 MiB)
```